### PR TITLE
Reword "credible solution"

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@ Recent [=AI systems=] are able to assist in the partial or complete creation of 
 That need is pressing directly for end-users as they individually consume content, but also applies to agents that end-users rely on: typically, search engines would likely benefit from transparency on purely AI generated content. Somewhat ironically, crawlers used to train AI models are likely to need such a signal as well, since [=training=] models on the output of models may create unexpected and unwanted results.
 </p>
 <p>
-We do not know of any credible solution that could guarantee (e.g., through cryptography) that a given piece of content was or was not generated (partially or entirely) by [=AI systems=]. That gap unfortunately leaves a systemic risk in terms of misinformation and spam that should be of grave concern for the health of the Web as a content distribution platform and of society as a whole.
+We do not know of any solution that could guarantee (e.g., through cryptography) that a given piece of content was or was not generated (partially or entirely) by [=AI systems=]. That gap unfortunately leaves a systemic risk in terms of misinformation and spam that should be of grave concern for the health of the Web as a content distribution platform and of society as a whole.
 </p>
 <div id=b1 class=advisement>
 <p>


### PR DESCRIPTION
My thinking here is that by saying "credible solution" is that you know of proposed solutions but don't think they're credible - which raises the question of which ones and why. So I suggest removing "credible" to avoid that implication.